### PR TITLE
A restructure on first principles

### DIFF
--- a/02-Expectations.md
+++ b/02-Expectations.md
@@ -15,8 +15,5 @@ Meetings are a necessary evil. We try to keep meetings to a minimum and focus on
 
 ### Effective Use of P2
 
-This document outlines best practices for using P2 for product management communication at WordPress VIP.
-
-*Add content here about effective P2 usage for product management.*
 
 ### Documentation

--- a/05-Tools-and-Technologies.md
+++ b/05-Tools-and-Technologies.md
@@ -1,15 +1,12 @@
 ## Tools and Technologies
 
 Explore the tools and technologies that support product management at WordPress VIP. This section introduces our communication platforms, project threads, release planning, and analytics tools.
-### Communication Tools
 
-This document outlines the communication tools used at WordPress VIP for product management.
-
-*Add content here about communication tools like P2, Slack, and IRC.*
 
 ### Linear
 
-### Projects 
+#### Projects 
+
 #### Release Plans
 
 ### P2

--- a/06-Best-Practices.md
+++ b/06-Best-Practices.md
@@ -1,34 +1,15 @@
 ## Best Practices
 
 This section highlights the best practices for product management at WordPress VIP, including agile methodologies, lean development, data-driven decision making, and user-centered design.
+
 ### Agile Methodologies
 
-This document outlines how agile methodologies are applied to product management at WordPress VIP.
-
-*Add content here about agile methodologies used at WordPress VIP.*
 ### Lean Product Development
 
-This document outlines how lean product development principles are applied at WordPress VIP.
-
-*Add content here about lean product development methodologies used at WordPress VIP.*
 ### Data-Driven Decision Making
 
-This document outlines how data-driven decision making is implemented at WordPress VIP.
-
-*Add content here about data-driven decision making methodologies used at WordPress VIP.*
 ### User-Centered Design
-
-This document outlines how user-centered design principles are applied at WordPress VIP.
-
-*Add content here about user-centered design methodologies used at WordPress VIP.*
 
 ### Writing Clear and Concise Product Specs
 
-This document outlines best practices for writing clear and concise product specifications at WordPress VIP.
-
-*Add content here about writing effective product specifications.*
 ### Maintaining Documentation
-
-This document outlines best practices for maintaining product documentation at WordPress VIP.
-
-*Add content here about documentation maintenance strategies.*

--- a/07-Metrics-and-KPIs.md
+++ b/07-Metrics-and-KPIs.md
@@ -1,18 +1,12 @@
 ## Metrics and KPIs
 
-Learn how WordPress VIP defines, tracks, and uses metrics and KPIs to measure product success and inform decision making.
+Learn how WordPress VIP Product defines, tracks, and uses metrics and KPIs to measure product success and inform decision making.
+
 ### Defining Success Metrics
 
-This document outlines how to define success metrics for products at WordPress VIP.
 
-*Add content here about defining and using success metrics.*
 ### Regular Reporting and Review
 
-This document outlines best practices for regular reporting and review of product metrics at WordPress VIP.
 
-*Add content here about reporting and review methodologies.*
 ### Using Data to Inform Decisions
 
-This document outlines how data is used to inform product decisions at WordPress VIP.
-
-*Add content here about data-driven decision making in product management.*

--- a/08-Training-and-Development.md
+++ b/08-Training-and-Development.md
@@ -1,26 +1,15 @@
 ## Training and Development
 
 Continuous learning and professional development are core to our culture. This section provides resources and guidance for onboarding, ongoing training, and professional growth at WordPress VIP.
+
 ### Onboarding New Team Members
 
-This document outlines the onboarding process for new team members at WordPress VIP.
-
-*Add content here about onboarding best practices.*
 ### Continuous Professional Development
 
-This document outlines opportunities and best practices for continuous professional development at WordPress VIP.
-
-*Add content here about continuous professional development.*
 ### Learning Resources and Opportunities
 
-This document outlines learning resources and opportunities for product managers at WordPress VIP.
-
-*Add content here about learning resources and opportunities.*
 ### Recommended Training
 
-This document outlines recommended training for product managers at WordPress VIP.
-
-*Add content here about recommended training programs or materials.*
 ### Other Resources
 
 - [FG: Automattic Developer Team Lead Expectations](https://fieldguide.automattic.com/developer-team-leads/developer-lead-expectations/)

--- a/10-Product ideas Process
+++ b/10-Product ideas Process
@@ -1,0 +1,21 @@
+This is an outline for a VIP Product ideas/feedback process that encompasses collection, evaulation, prioritization, and development.
+
+1: Product ideas/feedback collection
+  - Current state: Ideas/feedback live in different places
+      - Parse.ly: starts in #vip-parsely-product-ideas Slack channel and goes to Parse.ly Product Ideas Asana project (https://app.asana.com/1/26890605006346/project/1201360835849565/list/1205115462862750) via Zapier; some ideas are also in P2s
+      - CMS & Platform: starts in Pendo Feedback (transitioning to Listen)
+  - Future state: All ideas/feedback originate in Pendo Listen
+
+2: Product ideas/feedback evaluation
+ - Current state: There is no process outlined for this. 
+ - Future state: Pendo Listen attaches customer details (i.e. ARR) to product ideas. We can use this to determine recommendations for the VIP roadmap.
+
+ 3. Product ideas/feedback prioritization
+ - Current state: There is no process outlined for this.
+ - Future state: Ideas are prioritized by business impact. Laura suggests ARR is a major consideration, and we should determine what else factors in.
+
+ 4. Product ideas/feedback development
+ - Current state: Products and features currently in development are within Linear projects.
+ - Future state: Prioritized ideas should be exported to Linear into a backlog of issues or into active projects for immediate development. All ideas (now issues) should have an effort measure (i.e. t-shirt sizes). This allows for engineers to pick up "small" issues when they are looking for work in addition to any active development project work.
+
+ Additional considerations: Where does AI fit in? See Jarek's ideas here: https://parselyproductteam.wordpress.com/2025/04/22/can-ai-help-us-figure-out-what-to-work-on-next/

--- a/_tmp-outline.md
+++ b/_tmp-outline.md
@@ -1,0 +1,41 @@
+# Outline
+
+A temporary file outlining the whole handbook to work through ideas and assignments.
+
+* Core Principles
+  * Customer Centric (I will build our business sustainably through passionate and loyal customers) - getting close to customers is where we start
+  * Thoughtful (I will never stop learning) - take what we hear from customers and seek to deeply understand it.
+  * Unafraid (I know there’s no such thing as a status quo) - Ship to learn, and stick it out long enough to learn.
+  * Collaborative ( I will never pass up an opportunity to help out a colleague) - We work with patners to deliver value everywhere.
+  * Humble (I’ll remember the days before I knew everything) - We will fall in love with the problem and allow ourselves to be surprised by the solution.
+* Expectations
+ * Customer Centric - e.g. talk to customers once a week
+  * Thougtful - reflect, don't act too quickly
+  * Unafraid - how we push back
+  * Collaborative - who are our partners, how do we treat them
+  * Humble - what's our tone, how do we cultivate surprise
+* Metrics and KPIs
+  * Customer Centric
+  * Thougtful
+  * Unafraid
+  * Collaborative
+  * Humble
+* Practices
+  * Customer Centric
+     * Customr interviews
+     * Drinking our own champagne
+     * Product ideas
+  * Thougtful
+    * Interview summaries
+  * Unafraid
+    * Adoption reporting
+  * Collaborative
+  * Humble
+* Training and Development
+  * Customer Centric
+    * Continuous interviewing
+  * Thougtful
+  * Unafraid
+  * Collaborative
+    * Reboot
+  * Humble

--- a/_tmp-outline.md
+++ b/_tmp-outline.md
@@ -8,6 +8,11 @@ A temporary file outlining the whole handbook to work through ideas and assignme
   * Unafraid (I know there’s no such thing as a status quo) - Ship to learn, and stick it out long enough to learn.
   * Collaborative ( I will never pass up an opportunity to help out a colleague) - We work with patners to deliver value everywhere.
   * Humble (I’ll remember the days before I knew everything) - We will fall in love with the problem and allow ourselves to be surprised by the solution.
+  * The PM Loop:
+    * Discover (Humble, Customer Centric)
+    * Design (Thoughtful, Collaborative)
+    * Develop (Customer Centric, Collaborative)
+    * Deliver (Unafraid, Customer Centric)
 * Expectations
  * Customer Centric - e.g. talk to customers once a week
   * Thougtful - reflect, don't act too quickly
@@ -15,23 +20,22 @@ A temporary file outlining the whole handbook to work through ideas and assignme
   * Collaborative - who are our partners, how do we treat them
   * Humble - what's our tone, how do we cultivate surprise
 * Metrics and KPIs
-  * Customer Centric
-  * Thougtful
-  * Unafraid
-  * Collaborative
-  * Humble
+  * Discover
+  * Design
+  * Develop
+  * Deliver
 * Practices
-  * Customer Centric
+  * Discover
      * Customr interviews
      * Drinking our own champagne
      * Product ideas
-  * Thougtful
+  * Design
     * Interview summaries
-  * Unafraid
+  * Develop
+    * Projects
+  * Deliver
     * Adoption reporting
-  * Collaborative
-  * Humble
-* Training and Development
+  Training and Development
   * Customer Centric
     * Continuous interviewing
   * Thougtful
@@ -39,3 +43,7 @@ A temporary file outlining the whole handbook to work through ideas and assignme
   * Collaborative
     * Reboot
   * Humble
+  * Discover
+  * Design
+  * Develop
+  * Deliver

--- a/_tmp-outline.md
+++ b/_tmp-outline.md
@@ -19,11 +19,6 @@ A temporary file outlining the whole handbook to work through ideas and assignme
   * Unafraid - how we push back
   * Collaborative - who are our partners, how do we treat them
   * Humble - what's our tone, how do we cultivate surprise
-* Metrics and KPIs
-  * Discover
-  * Design
-  * Develop
-  * Deliver
 * Practices
   * Discover
      * Customr interviews
@@ -47,3 +42,10 @@ A temporary file outlining the whole handbook to work through ideas and assignme
   * Design
   * Develop
   * Deliver
+
+## Future
+We should have these sections but I don't think we are ready yet.
+
+* Metrics and KPIs - I think we are too young to set these at present.
+* Tools and Technology - We should use tool #tags in the other parts of the handbook that link to a consolidated page, I think the build script can help with this.
+* Playbooks - We don't have these yet, but as we start to follow the handbook we should add them.


### PR DESCRIPTION
This attempts to distill the core principles into a way to organize our work alongside the PM Loop.

I created a _tmp-outline.md because I realized we need to agree on an overall outline before we start building sections.

I think this is a good first version of the handbook, and one we can deliver by the end of the meetup.
